### PR TITLE
Remove HDF5 Dependency

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,8 +20,6 @@ docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 libgdal:
 - '3.11'
-libnetcdf:
-- 4.9.2
 libxml2:
 - '2.13'
 target_platform:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-hdf5:
-- 1.14.6
 libgdal:
 - '3.11'
 libnetcdf:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
-hdf5:
-- 1.14.6
 libgdal:
 - '3.11'
 libnetcdf:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -20,8 +20,6 @@ cxx_compiler_version:
 - '18'
 libgdal:
 - '3.11'
-libnetcdf:
-- 4.9.2
 libxml2:
 - '2.13'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -10,8 +10,6 @@ cxx_compiler:
 - vs2022
 libgdal:
 - '3.11'
-libnetcdf:
-- 4.9.2
 libxml2:
 - '2.13'
 target_platform:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -8,8 +8,6 @@ channel_targets:
 - conda-forge main
 cxx_compiler:
 - vs2022
-hdf5:
-- 1.14.6
 libgdal:
 - '3.11'
 libnetcdf:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
 
-  number: 2
+  number: 3
 
   run_exports:
     - {{ pin_subpackage('mdal', max_pin='x.x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
 
-  number: 1
+  number: 2
 
   run_exports:
     - {{ pin_subpackage('mdal', max_pin='x.x') }}
@@ -25,7 +25,6 @@ requirements:
     - make  # [unix]
   host:
     - libgdal
-    - hdf5
     - libnetcdf
     - libxml2
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - make  # [unix]
   host:
     - libgdal
-    - libnetcdf
     - libxml2
   run:
 


### PR DESCRIPTION
Remove HDF5 dependency and fall back to GDAL dependency. This avoids a clash between the two that has recently caused the package build to fail. Also NetCDF

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
